### PR TITLE
delete empty base rosters

### DIFF
--- a/fetchers/base_rosters.rb
+++ b/fetchers/base_rosters.rb
@@ -7,14 +7,14 @@ require_relative '../api/client'
 
 class BaseRostersFetcher < BatchFetcher
   def run_for_batch(team_ids)
-    p 'teams_ids'
-    p team_ids
     puts "importing rosters for up to #{team_ids.size} teams"
     rosters_raw = fetch_rosters(team_ids)
     puts "fetched data for #{rosters_raw.size} teams"
 
-    rosters = present_rosters(rosters_raw)
+    rosters_to_delete = rosters_raw.select { |team_id, team_rosters| team_rosters.empty? }.keys
+    delete_empty_rosters(rosters_to_delete) unless rosters_to_delete.empty?
 
+    rosters = present_rosters(rosters_raw)
     ids_to_update = rosters.reduce(Set.new) { |ids, roster| ids << roster[:team_id] }.to_a
     puts "importing data for #{ids_to_update.size} teams"
     BaseRostersImporter.import(data: rosters, ids: ids_to_update)
@@ -25,7 +25,7 @@ class BaseRostersFetcher < BatchFetcher
     ids.each_with_object({}) do |id, hash|
       hash[id] = @api_client.team_rosters(team_id: id)
       puts "fetched roster for team #{hash.size}" if hash.size % 10 == 0
-    end.compact
+    end
   end
 
   def present_rosters(hash)
@@ -40,5 +40,10 @@ class BaseRostersFetcher < BatchFetcher
         }
       end
     end
+  end
+
+  def delete_empty_rosters(team_ids)
+    puts "will delete rosters for these teams: #{team_ids}"
+    BaseRostersImporter.delete_rosters_for(team_ids: team_ids)
   end
 end

--- a/importers/base_roster_importer.rb
+++ b/importers/base_roster_importer.rb
@@ -20,4 +20,8 @@ class BaseRostersImporter < TempTableStrategy
   def main_table_name
     :base_rosters
   end
+
+  def self.delete_rosters_for(team_ids:)
+    DB[:base_rosters].where(team_id: team_ids).delete
+  end
 end


### PR DESCRIPTION
When we receive responses with no rosters, we should remove all `base_rosters` entries with this team_id, otherwise some players might end up on two base rosters at the same time:
1. Player X is added to a roster A.
2. We sync this roster to our database.
3. It turns out that roster A was created by mistake, and all roster A players are moved to an already existing roster B, leaving roster A empty.
4. We sync roster B, but we do nothing about roster A (since it’s now empty and skip over empty responses).
5. Player X is now on two rosters, which means that during rating calculations we get erroneous (and random, because of the undefined sorting outcomes) results.

So now we are deleting all entries from the `base_rosters` table when there are no rosters.

Note that the case when roster A has earlier rosters or an active roster for this season has already been handled correctly, since we rewrite all `base_rosters` entries for such teams on each run.