### PR TITLE
handle json parsing errors in api client

### DIFF
--- a/api/client.rb
+++ b/api/client.rb
@@ -62,8 +62,9 @@ class APIClient
   end
 
   def fetch(query)
-    self.class.get(query.to_s, headers: @headers).parsed_response
-  rescue SocketError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+    response = self.class.get(query.to_s, headers: @headers)
+    JSON.parse(response.body)
+  rescue SocketError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, JSON::ParserError
     puts "connection refused at #{query}, retrying in 3 seconds"
     sleep(3)
     retry

--- a/fetchers/base_rosters.rb
+++ b/fetchers/base_rosters.rb
@@ -39,10 +39,6 @@ class BaseRostersFetcher < BatchFetcher
 
   def present_rosters(hash)
     hash.flat_map do |team_id, players|
-      if players.is_a? String
-        puts "Malformed data for team #{team_id}, skipping it"
-        next
-      end
       players.flat_map do |player|
         {
           team_id: player['idteam'],


### PR DESCRIPTION
When api.rating.chgk.net returns 503, it is not json but html. Instead of handling parsing errors later, we should wait and retry in the api client.