### PR TITLE
run vacuum task using a separate connection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -132,7 +132,7 @@ end
 
 task :vacuum do
   puts 'starting VACUUM FULL'
-  DB.vacuum_full
+  vacuum_full
   puts 'finished VACUUM FULL'
 end
 

--- a/db.rb
+++ b/db.rb
@@ -37,5 +37,9 @@ def recent_tournaments(days:)
 end
 
 def vacuum_full
-  DB.run("vacuum full")
+  # We need another connection, with a larger statement timeout
+  ENV['PGOPTIONS'] = '-c statement_timeout=3600s'
+  connection_string = ENV.fetch('CONNECTION_STRING', 'postgres://localhost/postgres')
+  connection = Sequel.connect(connection_string)
+  connection.run('vacuum full')
 end


### PR DESCRIPTION
Default 60-seconds statement timeout is too short for vacuuming. 