### PR TITLE
fix sqlite backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,14 @@ RUN python3 -m venv /venv && \
 
 # Run and own the application files as a non-root user for security
 RUN useradd ruby --home /app --shell /bin/bash
-USER ruby:ruby
 
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build --chown=ruby:ruby /app /app
+
+RUN chmod -R 777 /app
+
+USER ruby:ruby
 
 # Copy application code
 COPY . .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,9 +60,8 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
-  arm64-darwin-22
-  x86_64-darwin-20
-  x86_64-darwin-21
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/backup/r2.rb
+++ b/backup/r2.rb
@@ -1,26 +1,24 @@
 # frozen_string_literal: true
 
-module Backup
-  module R2
-    extend Loggable
+module R2
+  extend Loggable
 
-    def self.client
-      access_key_id = ENV.fetch('R2_ACCESS_KEY_ID', nil)
-      secret_access_key = ENV.fetch('R2_SECRET_ACCESS_KEY', nil)
-      cloudflare_account_id = ENV.fetch('R2_ACCOUNT_ID', nil)
+  def self.client
+    access_key_id = ENV.fetch('R2_ACCESS_KEY_ID', nil)
+    secret_access_key = ENV.fetch('R2_SECRET_ACCESS_KEY', nil)
+    cloudflare_account_id = ENV.fetch('R2_ACCOUNT_ID', nil)
 
-      Aws::S3::Client.new(access_key_id:,
-                          secret_access_key:,
-                          endpoint: "https://#{cloudflare_account_id}.r2.cloudflarestorage.com",
-                          region: 'auto')
-    end
+    Aws::S3::Client.new(access_key_id:,
+                        secret_access_key:,
+                        endpoint: "https://#{cloudflare_account_id}.r2.cloudflarestorage.com",
+                        region: 'auto')
+  end
 
-    def self.upload_file(filename)
-      logger.info "uploading #{filename} to R2"
-      r2_object = Aws::S3::Object.new('rating-backups', "#{Date.today}_#{filename}", client:)
-      r2_object.upload_file(filename)
+  def self.upload_file(filename)
+    logger.info "uploading #{filename} to R2"
+    r2_object = Aws::S3::Object.new('rating-backups', "#{Date.today}_#{File.basename(filename)}", client:)
+    r2_object.upload_file(filename)
 
-      logger.info 'uploaded to R2'
-    end
+    logger.info 'uploaded to R2'
   end
 end


### PR DESCRIPTION
Because of missing permissions on `/app` for cron jobs, sqlite backups jobs were failing. I’ve also reworked `Backup` into a class to share values of a sqlite path and a schema name.